### PR TITLE
Fixed a typo in the 'Series Object' lesson.

### DIFF
--- a/problems/series_object/solution.js
+++ b/problems/series_object/solution.js
@@ -18,7 +18,7 @@ async.series({
   },
   requestTwo: function(done){
     var body = '';
-    http.get(process.argv[2], function(res){
+    http.get(process.argv[3], function(res){
       res.on('data', function(chunk){
         body += chunk.toString();
       });


### PR DESCRIPTION
I've fixed a typo in the solution.js file of the 'Series Object' lesson, since you were passing the first command-line argument twice.
