### PR TITLE
Fix whilst setup and solution

### DIFF
--- a/problems/whilst/setup.js
+++ b/problems/whilst/setup.js
@@ -4,21 +4,36 @@ var http = require('http');
 var max = Math.floor(Math.random() * 5) + 1;
 max = (max == 1 ? 2: max)
 
+var port1= 9345, port2 = 9346;
+
 module.exports = function () {
-  var count = 0;
-  var server = http.createServer(function (req, res) {
-    if (count >= max) {
-      res.end('meerkat');
-    } else {
-      ++count;
-      res.end();
-    }
-  }).listen(9345);
+  var servers = [];
+
+  function startServer(port){
+    var count = 0;
+    var server = http.createServer(function (req, res) {
+      if (count >= max) {
+        res.end('meerkat');
+      } else {
+        ++count;
+        res.end();
+      }
+    }).listen(port);
+    servers.push(server);
+  }
+
+  startServer(port1);
+  startServer(port2);
+
+  function stopServers(){
+    servers.forEach(function(server){ server.close(); });
+  }
 
   return {
-      args  : 'http://localhost:9345'
+      submissionArgs: 'http://localhost:' + port1
+    , solutionArgs: 'http://localhost:' + port2
     , stdin : null
     , long  : true
-    , close : server.close.bind(server)
+    , close : stopServers
   }
 }

--- a/problems/whilst/solution.js
+++ b/problems/whilst/solution.js
@@ -3,7 +3,7 @@ var http = require('http')
 
 var requestBody = '';
 
-var count = 1;
+var count = 0;
 
 async.whilst(
   function() {
@@ -15,10 +15,10 @@ async.whilst(
     http.get(process.argv[2], function(res){
       res.on('data', function(chunk){
         body += chunk.toString();
-        ++count;
       });
 
       res.on('end', function(){
+        ++count;
         requestBody = body;
         done();
       });


### PR DESCRIPTION
This should fix https://github.com/bulkan/async-you/issues/9

I think there a variety of issues with `whilst`, running on my local machine, I noticed:
- the server is not restarted between running the student's solution and the suggested solution, so their requests can interfere with each other. The server could be waiting for 5 reqs before responding with `meerkat`, and get 3 from the student's solution and 2 from the suggested solution, both will end up with the wrong answer!
- the current suggested solution always returns 2 because it starts a tiny bit later than the student's solution, when the server has (almost always) started returning `meerkat` already, so it just counts 1 `data` event plus the initial value of 1.

We can get around the solution interference problems by starting two servers, and returning an object from `setup.js` with both `submissionArgs` and `solutionArgs`, instead of just `args`.

For fixing the solution itself, I think we should start with `count = 0;` and increment either at the start or end of a request.
