### PR TITLE
Removed extra bracket and corrected parameter name so that sample code w...

### DIFF
--- a/problems/waterfall/problem.txt
+++ b/problems/waterfall/problem.txt
@@ -37,7 +37,7 @@ property then it does another GET request.
           res.on('end', function(){
             cb(null, body);
           });
-        }).on('error'), function(e) {
+        }).on('error', function(err) {
           cb(err);
         });
       },


### PR DESCRIPTION
...orks

These minor code changes enable the sample code to run. 

1) The bracket after 'error' is a typo, and the closing bracket already exists in the proper position. 
2) The parameter 'e' has been changed to 'err' to match its use on the next line.
