### PR TITLE
Times fix verification

### DIFF
--- a/problems/times/setup.js
+++ b/problems/times/setup.js
@@ -28,7 +28,7 @@ module.exports = function () {
   var server2 = http.createServer(
     function(req, res){
       handleRequests(req, res, solutionUsers);
-      }
+    }
   ).listen(9346);
 
   return {


### PR DESCRIPTION
This pull request corrects the behaviour of verification for the times step.

I can provide more info on my code if requested. I have tried both to make the minimum possible changes, and to preserve the existing behaviour as much as possible.

NOTE: I believe that my tests are sufficient, and reflect how the workshopper executes the tutorial. 
However, this is an informed guess on my part, and working on workshop code is new to me.

Problem - 
The existing code creates a single server on 9345. However, the workshopper runs two processes, the 
student's answer and solution.js. Because the server is pushing each posted user, from both processes, onto the array, the array ends up with a duplicate set of users.

Depending on whether the student's answer or the solution.js calls http.get first, either the actual or 
expected results will show these duplicates.

Fix - 
The correct method (according to the workshopper docs) seems to be to have two servers, so I've implemented a second server on 9346. These servers are specified in the returned object.

I've created two arrays for storing both sets of posted users.

I haven't changed the server handler function, but I've extracted it out into a named function. This named 
function is passed to each server, inside a wrapper function that passes the relevant array for storing posted 
users.

Testing -
To test, I cloned the workshop, then used npm to install workshopper@0.4.1 and async, and checked with npm list that all dependencies are installed.

Then, in the async-you root folder, I've run "node async_you.js verify timesAnswer.js", where timesAnswer.js is my solution, copied into the async-you root folder. The actual and expected solutions matched. I also put a bug in my solution as a separate test, to confirm that failures are still detected.
