### PR TITLE
order users array before adding to response

### DIFF
--- a/problems/times/setup.js
+++ b/problems/times/setup.js
@@ -15,6 +15,9 @@ module.exports = function () {
         res.end();
       });
     } else {
+
+      users.sort(function(a, b) { return a.user_id - b.user_id; });
+
       res.end(JSON.stringify({'users': users}));
     }
   }


### PR DESCRIPTION
I am happy to provide further explanation, run more tests, or make revisions if requested for this PR.

The array sorting is required because the users are not necessarily received in the order they are sent.

In practice, this means that both the student's code and the workshopper solution both have an array of users, but probably not in the same order. So, Actual results do not match Expected results.

Apologies that this was not detected by my testing of my earlier PR. 
