### PR TITLE
Fix typo in results callback

### DIFF
--- a/problems/series_object/problem.txt
+++ b/problems/series_object/problem.txt
@@ -35,7 +35,7 @@ properties. The above example can be written like so:
       two: function(done){
         done(null, '2');
       }
-    }, function(err, result){
+    }, function(err, results){
       console.log(results);
       // results will be {one: 1, two: 2}
     });


### PR DESCRIPTION
Just a minor variable name mismatch.
